### PR TITLE
Fix name used in message sent to Hipchat

### DIFF
--- a/lib/hipchat_hooks.rb
+++ b/lib/hipchat_hooks.rb
@@ -2,7 +2,7 @@ class NotificationHook < Redmine::Hook::Listener
 
   def controller_issues_new_after_save(context={})
     issue = context[:issue]
-    author = CGI::escapeHTML(issue.author.name)
+    author = CGI::escapeHTML(User.current.name)
     tracker = CGI::escapeHTML(issue.tracker.name.downcase)
     subject = CGI::escapeHTML(issue.subject)
     url = get_url issue.id
@@ -14,7 +14,7 @@ class NotificationHook < Redmine::Hook::Listener
   def controller_issues_edit_after_save(context={})
     issue = context[:issue]
 
-    author = CGI::escapeHTML(issue.author.name)
+    author = CGI::escapeHTML(User.current.name)
     tracker = CGI::escapeHTML(issue.tracker.name.downcase)
     subject = CGI::escapeHTML(issue.subject)
     url = get_url issue.id


### PR DESCRIPTION
The message to hipchat was always showing the issue's author as the one
who saved/changed the issue. Changed this to use the name of the current
user
