### PR TITLE
Add support for project selection and wiki update notifications

### DIFF
--- a/app/views/shared/_settings.html.erb
+++ b/app/views/shared/_settings.html.erb
@@ -15,3 +15,8 @@
   <%= check_box_tag 'settings[notify]', 1, Setting.plugin_hipchat[:notify] %>
   Notify room members? Will trigger sound/popup based on user preferences.
 </p>
+
+<p>
+  <%= content_tag(:label, l(:hipchat_settings_label_projects)) %>
+  <%= select_tag 'settings[projects][]', project_tree_options_for_select(Project.active), :multiple => true, :size => Project.active.size %>
+</p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,3 +3,4 @@ en:
   hipchat_settings_label_room_id: Room ID
   hipchat_settings_label_auth_token: Room token
   hipchat_settings_label_notify: Notify
+  hipchat_settings_label_projects: Projects

--- a/lib/hipchat_hooks.rb
+++ b/lib/hipchat_hooks.rb
@@ -1,32 +1,51 @@
 class NotificationHook < Redmine::Hook::Listener
 
   def controller_issues_new_after_save(context={})
-    issue = context[:issue]
-    author = CGI::escapeHTML(User.current.name)
+    issue   = context[:issue]
+    return true unless Setting.plugin_hipchat[:projects].include?(issue.project_id.to_s)
+    author  = CGI::escapeHTML(User.current.name)
     tracker = CGI::escapeHTML(issue.tracker.name.downcase)
     subject = CGI::escapeHTML(issue.subject)
-    url = get_url issue.id
-    text = "#{author} reported #{tracker} <a href=\"#{url}\">##{issue.id}</a>: #{subject}"
+    url     = get_url issue
+    text    = "#{author} reported #{tracker} <a href=\"#{url}\">##{issue.id}</a>: #{subject}"
 
     send_message text
   end
 
   def controller_issues_edit_after_save(context={})
-    issue = context[:issue]
+    issue   = context[:issue]
+    return true unless Setting.plugin_hipchat[:projects].include?(issue.project_id.to_s)
 
-    author = CGI::escapeHTML(User.current.name)
+    author  = CGI::escapeHTML(User.current.name)
     tracker = CGI::escapeHTML(issue.tracker.name.downcase)
     subject = CGI::escapeHTML(issue.subject)
-    url = get_url issue.id
-    text = "#{author} updated #{tracker} <a href=\"#{url}\">##{issue.id}</a>: #{subject}"
+    url     = get_url issue
+    text    = "#{author} updated #{tracker} <a href=\"#{url}\">##{issue.id}</a>: #{subject}"
+
+    send_message text
+  end
+
+  def controller_wiki_edit_after_save(context={})
+    page    = context[:page]
+    return true unless Setting.plugin_hipchat[:projects].include?(page.wiki.project_id.to_s)
+    author  = CGI::escapeHTML(User.current.name)
+    wiki    = CGI::escapeHTML(page.pretty_title)
+    project = CGI::escapeHTML(page.wiki.project.name)
+    url     = get_url page
+    text    = "#{author} edited #{project} wiki page <a href=\"#{url}\">#{wiki}</a>"
 
     send_message text
   end
 
 private
 
-  def get_url(issue_id)
-    return "#{Setting[:protocol]}://#{Setting[:host_name]}/issues/#{issue_id}"
+  def get_url(object)
+    case object
+      when Issue    then "#{Setting[:protocol]}://#{Setting[:host_name]}/issues/#{object.id}"
+      when WikiPage then "#{Setting[:protocol]}://#{Setting[:host_name]}/projects/#{object.wiki.project.identifier}/wiki/#{object.title}"
+    else
+      RAILS_DEFAULT_LOGGER.info "Asked redmine_hipchat for the url of an unsupported object #{object.inspect}"
+    end
   end
 
   def send_message(message)


### PR DESCRIPTION
This lets the administrator select a list of projects for which the plugin will send notifications.  We currently have only one of many teams using Hipchat, so it's nice to not get notifications for events on other projects.

It also adds notifications for wiki edits.
