### PR TITLE
Keep project selection state

### DIFF
--- a/app/views/shared/_settings.html.erb
+++ b/app/views/shared/_settings.html.erb
@@ -18,5 +18,5 @@
 
 <p>
   <%= content_tag(:label, l(:hipchat_settings_label_projects)) %>
-  <%= select_tag 'settings[projects][]', project_tree_options_for_select(Project.active), :multiple => true, :size => Project.active.size %>
+  <%= select_tag 'settings[projects][]', project_tree_options_for_select(Project.active, :selected => Project.find(Setting.plugin_hipchat[:projects])), :multiple => true, :size => Project.active.size %>
 </p>


### PR DESCRIPTION
Returning to the plugin config page, the previously-selected projects were "remembered" but not selected in the project tree select box.  This commit fixes that.
