### PR TITLE
500 error with no projects selected in plugin config

### DIFF
--- a/app/views/shared/_settings.html.erb
+++ b/app/views/shared/_settings.html.erb
@@ -18,5 +18,5 @@
 
 <p>
   <%= content_tag(:label, l(:hipchat_settings_label_projects)) %>
-  <%= select_tag 'settings[projects][]', project_tree_options_for_select(Project.active, :selected => Project.find(Setting.plugin_hipchat[:projects])), :multiple => true, :size => Project.active.size %>
+  <%= select_tag 'settings[projects][]', project_tree_options_for_select(Project.active, :selected => Project.find_by_id(Setting.plugin_hipchat[:projects])), :multiple => true, :size => Project.active.size %>
 </p>


### PR DESCRIPTION
The first time I tried to go to the configuration page for this plugin, I got this error:

```
ActionView::TemplateError (Couldn't find Project without an ID) on line #21 of vendor/plugins/redmine_hipchat/app/views/shared/_settings.html.erb:
18: 
19: <p>
20:   <%= content_tag(:label, l(:hipchat_settings_label_projects)) %>
21:   <%= select_tag 'settings[projects][]', project_tree_options_for_select(Project.active, :selected => Project.find(Setting.plugin_hipchat[:projects])), :multiple => true, :size => Project.active.size %>
22: </p>

    app/models/project.rb:255:in `find'
    vendor/plugins/redmine_hipchat/app/views/shared/_settings.html.erb:21
...
```

I swapped in `Project.find_by_id` for `Project.find` so it fails more gracefully and there's just nothing pre-selected if it returns nil.
