### PR TITLE
Add utf-8 encoding header for Ruby 1.9.x

### DIFF
--- a/lib/hipchat_hooks.rb
+++ b/lib/hipchat_hooks.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 class NotificationHook < Redmine::Hook::Listener
 
   def controller_issues_new_after_save(context={})


### PR DESCRIPTION
Ruby 1.9.x doesn't like UTF-8 characters unless you specify the magic header.
