### PR TITLE
Allow configure HipChat room per projects

### DIFF
--- a/app/views/projects/_redmine_hipchat.html.erb
+++ b/app/views/projects/_redmine_hipchat.html.erb
@@ -1,0 +1,14 @@
+<p>
+  <%= form.text_field :hipchat_auth_token %>
+  A token from <a href="https://www.hipchat.com/group_admin/api" target="_blank">your API tokens page</a>. Leave empty for use global settings.
+</p>
+
+<p>
+  <%= form.text_field :hipchat_room_name %>
+  Target room's ID or name. Leave empty for use global settings.
+</p>
+
+<p>
+  <%= form.check_box :hipchat_notify %>
+  Notify room members? Will trigger sound/popup based on user preferences.
+</p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,3 +4,6 @@ en:
   hipchat_settings_label_auth_token: Room token
   hipchat_settings_label_notify: Notify
   hipchat_settings_label_projects: Projects
+  field_hipchat_auth_token: HipChat Room token
+  field_hipchat_room_name: HipChat Room ID
+  field_hipchat_notify: HipChat notify

--- a/db/migrate/20120917111848_add_hip_chat_token_and_room_id_to_project.rb
+++ b/db/migrate/20120917111848_add_hip_chat_token_and_room_id_to_project.rb
@@ -1,0 +1,7 @@
+class AddHipChatTokenAndRoomIdToProject < ActiveRecord::Migration
+  def change
+    add_column :projects, :hipchat_auth_token, :string, :default => "", :null => false
+    add_column :projects, :hipchat_room_name, :string, :default => "", :null => false
+    add_column :projects, :hipchat_notify, :boolean, :default => false, :null => false
+  end
+end

--- a/init.rb
+++ b/init.rb
@@ -8,6 +8,9 @@ Redmine::Plugin.register :redmine_hipchat do
 
   Rails.configuration.to_prepare do
     require_dependency 'hipchat_hooks'
+    require_dependency 'hipchat_view_hooks'
+    require_dependency 'project_patch'
+    Project.send(:include, RedmineHipchat::Patches::ProjectPatch)
   end
 
   settings :partial => 'settings/redmine_hipchat',

--- a/lib/hipchat_hooks.rb
+++ b/lib/hipchat_hooks.rb
@@ -1,46 +1,97 @@
 class NotificationHook < Redmine::Hook::Listener
 
-  def controller_issues_new_after_save(context={})
+  def controller_issues_new_after_save(context = {})
     issue   = context[:issue]
-    return true unless Setting.plugin_redmine_hipchat[:projects].include?(issue.project_id.to_s)
     project = issue.project
+    return true if !hipchat_configured?(project)
+
     author  = CGI::escapeHTML(User.current.name)
     tracker = CGI::escapeHTML(issue.tracker.name.downcase)
     subject = CGI::escapeHTML(issue.subject)
-    url     = get_url issue
+    url     = get_url(issue)
     text    = "#{author} reported #{project.name} #{tracker} <a href=\"#{url}\">##{issue.id}</a>: #{subject}"
 
-    send_message text
+    data          = {}
+    data[:text]   = text
+    data[:token]  = hipchat_auth_token(project)
+    data[:room]   = hipchat_room_name(project)
+    data[:notify] = hipchat_notify(project)
+
+    send_message(data)
   end
 
-  def controller_issues_edit_after_save(context={})
+  def controller_issues_edit_after_save(context = {})
     issue   = context[:issue]
-    return true unless Setting.plugin_redmine_hipchat[:projects].include?(issue.project_id.to_s)
     project = issue.project
+    return true if !hipchat_configured?(project)
+
     author  = CGI::escapeHTML(User.current.name)
     tracker = CGI::escapeHTML(issue.tracker.name.downcase)
     subject = CGI::escapeHTML(issue.subject)
     comment = CGI::escapeHTML(context[:journal].notes)
-    url     = get_url issue
+    url     = get_url(issue)
     text    = "#{author} updated #{project.name} #{tracker} <a href=\"#{url}\">##{issue.id}</a>: #{subject}"
     text   += ": <i>#{truncate(comment)}</i>" unless comment.blank?
 
-    send_message text
+    data          = {}
+    data[:text]   = text
+    data[:token]  = hipchat_auth_token(project)
+    data[:room]   = hipchat_room_name(project)
+    data[:notify] = hipchat_notify(project)
+
+    send_message(data)
   end
 
-  def controller_wiki_edit_after_save(context={})
+  def controller_wiki_edit_after_save(context = {})
     page    = context[:page]
-    return true unless Setting.plugin_redmine_hipchat[:projects].include?(page.wiki.project_id.to_s)
-    author  = CGI::escapeHTML(User.current.name)
-    wiki    = CGI::escapeHTML(page.pretty_title)
-    project = CGI::escapeHTML(page.wiki.project.name)
-    url     = get_url page
-    text    = "#{author} edited #{project} wiki page <a href=\"#{url}\">#{wiki}</a>"
+    project = page.wiki.project
+    return true if !hipchat_configured?(project)
 
-    send_message text
+    author       = CGI::escapeHTML(User.current.name)
+    wiki         = CGI::escapeHTML(page.pretty_title)
+    project_name = CGI::escapeHTML(project.name)
+    url          = get_url(page)
+    text         = "#{author} edited #{project_name} wiki page <a href=\"#{url}\">#{wiki}</a>"
+
+    data          = {}
+    data[:text]   = text
+    data[:token]  = hipchat_auth_token(project)
+    data[:room]   = hipchat_room_name(project)
+    data[:notify] = hipchat_notify(project)
+
+    send_message(data)
   end
 
-private
+  private
+
+  def hipchat_configured?(project)
+    if !project.hipchat_auth_token.empty? && !project.hipchat_room_name.empty?
+      return true
+    elsif Setting.plugin_redmine_hipchat[:projects] &&
+          Setting.plugin_redmine_hipchat[:projects].include?(project.id.to_s) &&
+          Setting.plugin_redmine_hipchat[:auth_token] &&
+          Setting.plugin_redmine_hipchat[:room_id]
+      return true
+    else
+      Rails.logger.info "Not sending HipChat message - missing config"
+    end
+    false
+  end
+
+  def hipchat_auth_token(project)
+    return project.hipchat_auth_token if !project.hipchat_auth_token.empty?
+    return Setting.plugin_redmine_hipchat[:auth_token]
+  end
+
+  def hipchat_room_name(project)
+    return project.hipchat_room_name if !project.hipchat_room_name.empty?
+    return Setting.plugin_redmine_hipchat[:room_id]
+  end
+
+  def hipchat_notify(project)
+    return project.hipchat_notify if !project.hipchat_auth_token.empty? && !project.hipchat_room_name.empty?
+    Setting.plugin_redmine_hipchat[:notify]
+  end
 
   def get_url(object)
     case object
@@ -51,20 +102,15 @@ private
     end
   end
 
-  def send_message(message)
-    if Setting.plugin_redmine_hipchat[:auth_token].empty? || Setting.plugin_redmine_hipchat[:room_id].empty?
-      Rails.logger.info "Not sending HipChat message - missing config"
-      return
-    end
-
-    Rails.logger.info "Sending message to HipChat: #{message}"
+  def send_message(data)
+    Rails.logger.info "Sending message to HipChat: #{data[:text]}"
     req = Net::HTTP::Post.new("/v1/rooms/message")
     req.set_form_data({
-      :auth_token => Setting.plugin_redmine_hipchat[:auth_token],
-      :room_id => Setting.plugin_redmine_hipchat[:room_id],
-      :notify => Setting.plugin_redmine_hipchat[:notify] ? 1 : 0,
+      :auth_token => data[:token],
+      :room_id => data[:room],
+      :notify => data[:notify] ? 1 : 0,
       :from => 'Redmine',
-      :message => message
+      :message => data[:text]
     })
     req["Content-Type"] = 'application/x-www-form-urlencoded'
 
@@ -85,5 +131,4 @@ private
     words = text.split()
     words[0..(length-1)].join(' ') + (words.length > length ? end_string : '')
   end
-
 end

--- a/lib/hipchat_view_hooks.rb
+++ b/lib/hipchat_view_hooks.rb
@@ -1,0 +1,3 @@
+class NotificationViewHook < Redmine::Hook::ViewListener
+  render_on(:view_projects_form, :partial => 'projects/redmine_hipchat', :layout => false)
+end

--- a/lib/project_patch.rb
+++ b/lib/project_patch.rb
@@ -1,0 +1,11 @@
+module RedmineHipchat
+  module Patches
+    module ProjectPatch
+      def self.included(base)
+        base.class_eval do
+          safe_attributes 'hipchat_auth_token', 'hipchat_room_name', 'hipchat_notify'
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Attached patch allow configure hipchat room per project. The logic is simple:
- If project have configured hipchat room, it will be used instead global room
- If project doesn't have configured, will be used global settings.
- If no global settings set, hipchat will not work.

This is code should not break exists installations.
